### PR TITLE
Add clr class to isChild field

### DIFF
--- a/contao/dca/tl_layout.php
+++ b/contao/dca/tl_layout.php
@@ -44,7 +44,7 @@ $GLOBALS['TL_DCA']['tl_layout']['fields']['isChild'] = [
     'inputType'     => 'checkbox',
     'eval'          => [
         'submitOnChange' => true,
-        'tl_class'       => 'long'
+        'tl_class'       => 'clr long'
     ],
     'save_callback' => [['ChildLayouts\Dca', 'checkIfChildPossible']],
     'sql'           => "char(1) NOT NULL default ''"


### PR DESCRIPTION
In Contao 4 (4.4.5) the long class alone does not break the column of the field.